### PR TITLE
Add shooting and new movement option

### DIFF
--- a/arduino/tank/tank.ino
+++ b/arduino/tank/tank.ino
@@ -46,6 +46,10 @@ void handleInput()
             car.setSpeed(bSpeed);
             car.setAngle(currentDegrees);
             break;
+        case 'c': //go straight
+            currentDegrees = 0;
+            car.setAngle(currentDegrees);
+            break;
         default: // if you receive something that you don't know, just stop
             car.setSpeed(0);
             car.setAngle(currentDegrees);

--- a/arduino/tank/tank.ino
+++ b/arduino/tank/tank.ino
@@ -5,6 +5,12 @@ const int bSpeed   = -70; // 70% of the full speed backward
 const int incrementalDegrees = 5; // degrees to turn
 int currentDegrees = 0;
 
+const int shootyPin = 250; //The emulator already have the shooting implemented in godot.
+//To shoot it, is only required to set the pin 250 to true.
+
+unsigned long lastShotTime = 0;
+const unsigned long SHOOT_RESET = 100;
+
 ArduinoRuntime arduinoRuntime;
 BrushedMotor leftMotor(arduinoRuntime, smartcarlib::pins::v2::leftMotorPins);
 BrushedMotor rightMotor(arduinoRuntime, smartcarlib::pins::v2::rightMotorPins);
@@ -15,6 +21,8 @@ SimpleCar car(control);
 void setup()
 {
     Serial.begin(9600);
+
+    pinMode(shootyPin, OUTPUT);
 }
 
 void loop()
@@ -24,6 +32,11 @@ void loop()
 
 void handleInput()
 { // handle serial input if there is any
+
+    unsigned long currentTime = millis();
+    if (currentTime == lastShotTime + SHOOT_RESET) {  //If the pin is set to low immediatly after it was set to high, the tank won't shoot.
+      digitalWrite(shootyPin, LOW);
+    }
     if (Serial.available())
     {
         char input = Serial.read(); // read everything that has been received so far and log down
@@ -50,6 +63,11 @@ void handleInput()
             currentDegrees = 0;
             car.setAngle(currentDegrees);
             break;
+        break;
+        case 's': //shoot
+          digitalWrite(shootyPin, HIGH);
+          lastShotTime = currentTime;
+          break;
         default: // if you receive something that you don't know, just stop
             car.setSpeed(0);
             car.setAngle(currentDegrees);


### PR DESCRIPTION
Add a new case in the switch block (case 'c') that resets the steering angle to 0 in order to make the navigation easier. It also add another case (case 's')  so the tank can shoot.

Related issues: #3 , #14 