### PR TITLE
Java server damage logic

### DIFF
--- a/java-server/src/main/java/App.java
+++ b/java-server/src/main/java/App.java
@@ -1,1 +1,0 @@
-// Placeholder file

--- a/java-server/src/main/java/Connection.java
+++ b/java-server/src/main/java/Connection.java
@@ -22,7 +22,6 @@ public class Connection implements MqttCallback {
 
 	public void subscribe(MqttClient client) throws Exception {
 		Connection connection = new Connection();
-//		MqttClient client = connection.getClient();
 		client.setCallback(connection);
 		client.connect();
 		client.subscribe(MQTT_TOPIC);
@@ -59,7 +58,7 @@ public class Connection implements MqttCallback {
 		// not used
 	}
 
-	// Main method for testing from Java server
+//	 Main method for testing from Java server
 	public static void main(String[] args) {
 		try {
 			client = new MqttClient(LOCAL_HOST, DEFAULT_CLIENT_ID, persistance);

--- a/java-server/src/main/java/Connection.java
+++ b/java-server/src/main/java/Connection.java
@@ -35,10 +35,6 @@ public class Connection implements MqttCallback {
 		}
 	}
 
-	public MqttClient getClient() {
-		return this.client;
-	}
-
 	@Override
 	public void connectionLost(Throwable throwable) {
 		System.out.println("Connection to the MQTT broker lost!");
@@ -55,7 +51,7 @@ public class Connection implements MqttCallback {
 
 	@Override
 	public void deliveryComplete(IMqttDeliveryToken iMqttDeliveryToken) {
-		// not used
+		System.out.println("Message delivered");
 	}
 
 //	 Main method for testing from Java server
@@ -69,7 +65,5 @@ public class Connection implements MqttCallback {
 			e.printStackTrace();
 		}
 	}
-
-
 }
 

--- a/java-server/src/main/java/Tank.java
+++ b/java-server/src/main/java/Tank.java
@@ -29,6 +29,7 @@ public class Tank {
 		System.out.println(updatedHealth);						//printing for testing purpose
 		currentHealth.setPayload(updatedHealth.getBytes());
 		connection.publish(MQTT_TOPICS[0], currentHealth);
+
 		if (healthPoints == 0) {
 			System.out.println("Tank destroyed, GAME OVER!");	//printing for testing purpose
 			connection.unsubscribe(client);

--- a/java-server/src/main/java/Tank.java
+++ b/java-server/src/main/java/Tank.java
@@ -1,23 +1,39 @@
 import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
 
 public class Tank {
-	// Placeholder class for tank
-	private MqttClient client;
 
-	public Tank(MqttClient client) {
-		// Constructor for tank
+	private final String TANK_DESTROYED = "Tank destroyed!";
+	private final int DAMAGE_TAKEN = 1;
+	private int healthPoints = 200;
+	private MqttClient client;
+	private String token;
+	MqttMessage currentHealth = new MqttMessage();
+	MqttMessage tnkDestroyed = new MqttMessage();
+	Connection connection = new Connection();
+	private final String[] MQTT_TOPICS = {
+			"/tnk/status/hp",
+			"/tnk/status/elim"
+	};
+
+	public Tank(MqttClient client) throws Exception {
 		this.client = client;
 	}
 
-	public void setSpeed(int speed) {
-		// Sets tank speed
-	}
-
-	public void setHealth(int health) {
-		// Sets tank health
-	}
-
-	public void takeDamage(int damage) {
-		// Reduces health from damage
+	//Deducts health points from the tank, then proceeds to publish updated healthpoints to the broker,
+	//if healthPoints reaches 0, the client unsubscribes from "tnk/dmg" and publishes death message to the broker
+	public void takeDamage() {
+		healthPoints = healthPoints - DAMAGE_TAKEN;
+		String updatedHealth = Integer.toString(healthPoints);
+		System.out.println(updatedHealth);						//printing for testing purpose
+		currentHealth.setPayload(updatedHealth.getBytes());
+		connection.publish(MQTT_TOPICS[0], currentHealth);
+		if (healthPoints == 0) {
+			System.out.println("Tank destroyed, GAME OVER!");	//printing for testing purpose
+			connection.unsubscribe(client);
+			tnkDestroyed.setPayload(TANK_DESTROYED.getBytes());
+			connection.publish(MQTT_TOPICS[1], tnkDestroyed);
+		}
 	}
 }


### PR DESCRIPTION
In this pull request, logic for the server has been implemented. The server is subscribing and publishing data to and from the MQTT broker. The tank class has been implemented with logic that will reduce the healthpoints of the tank whenever a message is published from the emulator. 

Related issues: #7 #22  #21 
Closes #7 
Closes #22
Closes #21

### :ballot_box_with_check: Definition of Done checklist
- [x] Meaningful title and valuable description in pull request
- [x] Code change tested manually if not covered by automated tests
- [x] Pull request linked to one or more issues/stories
- [x] Acceptance criteria of the linked stories satisfied
- [x] Code change comprehended by those who approved it
- [x] State of target branch maintained or improved after the code change
